### PR TITLE
Fix deprecation warnings in database setup and report exports

### DIFF
--- a/app/api/v1/endpoints/reports.py
+++ b/app/api/v1/endpoints/reports.py
@@ -454,7 +454,7 @@ def get_executive_summary(
 
 @router.get("/export/projects")
 def export_projects_report(
-    format: str = Query("csv", regex="^(csv|excel|pdf)$"),
+    format: str = Query("csv", pattern="^(csv|excel|pdf)$"),
     portfolio_id: Optional[int] = None,
     db: Session = Depends(get_db),
     current_user: dict = Depends(get_current_user)
@@ -470,7 +470,7 @@ def export_projects_report(
 
 @router.get("/export/features")
 def export_features_report(
-    format: str = Query("csv", regex="^(csv|excel|pdf)$"),
+    format: str = Query("csv", pattern="^(csv|excel|pdf)$"),
     project_id: Optional[int] = None,
     db: Session = Depends(get_db),
     current_user: dict = Depends(get_current_user)

--- a/app/database.py
+++ b/app/database.py
@@ -3,8 +3,7 @@ Database configuration and connection management for GenAI Metrics Dashboard
 Optimized for performance with connection pooling and monitoring
 """
 from sqlalchemy import create_engine, event
-from sqlalchemy.ext.declarative import declarative_base
-from sqlalchemy.orm import sessionmaker
+from sqlalchemy.orm import declarative_base, sessionmaker
 from sqlalchemy.pool import QueuePool
 import os
 import logging


### PR DESCRIPTION
## Summary
- use modern `sqlalchemy.orm.declarative_base` import
- replace deprecated `regex` argument with `pattern` in report exports

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c14158e3b0832d8a328131575be20b